### PR TITLE
Deploy into azimuth management cluster 

### DIFF
--- a/azimuth_apps/models/v1alpha1/app_template.py
+++ b/azimuth_apps/models/v1alpha1/app_template.py
@@ -82,6 +82,13 @@ class AppTemplateSpec(schema.BaseModel):
             "If not given, the platform name is used"
         ),
     )
+    management_install: schema.conbool() = Field(
+        False,
+        description=(
+            "Boolean for installing Helmrelease in the Azimuth management "
+            "Cluster, instead of the usual resources cluster."
+        ),
+    )
 
 
 class AppTemplateVersion(schema.BaseModel):

--- a/azimuth_apps/models/v1alpha1/app_template.py
+++ b/azimuth_apps/models/v1alpha1/app_template.py
@@ -82,7 +82,7 @@ class AppTemplateSpec(schema.BaseModel):
             "If not given, the platform name is used"
         ),
     )
-    management_install: schema.conbool() = Field(
+    management_install: bool = Field(
         False,
         description=(
             "Boolean for installing Helmrelease in the Azimuth management "

--- a/azimuth_apps/operator.py
+++ b/azimuth_apps/operator.py
@@ -529,7 +529,7 @@ async def reconcile_app(instance: api.App, **kwargs):
         instance.spec.values,
         instance.metadata.name,
         template.spec.namespace or instance.metadata.name,
-        instance.spec.kubeconfig_secret.name,
+        None if (template.spec.managment_install) else  instance.spec.kubeconfig_secret.name,
         instance.spec.kubeconfig_secret.key,
     ):
         await ekclient.apply_object(resource, force=True)


### PR DESCRIPTION
A patch for apps operator that allows Helmreleases to be deployed directly into the management cluster, to allow less conventional Helmchart deployments (needed for deploying slinky via azimuth due to CRD dependency chains).