### PR TITLE
Dockerfile: Bump to Helm version 4.2.3 and use pyhelm3 version 0.5.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get install -y wget && \
     rm -rf /var/lib/apt/lists/*
 
-ARG HELM_VERSION=v3.20.1
+ARG HELM_VERSION=v4.2.3
 RUN set -ex; \
     OS_ARCH="$(uname -m)"; \
     case "$OS_ARCH" in \

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ MarkupSafe==3.0.3
 multidict==6.7.1
 propcache==0.4.1
 pydantic==2.13.0
-pyhelm3==0.4.0
+pyhelm3==0.5.3
 python-json-logger==4.1.0
 PyYAML==6.0.3
 sniffio==1.3.1


### PR DESCRIPTION
In order to use the Helm v4 we need the corresponding python package update and dependabot won't do the two together.