### PR TITLE
Make helm-unittest cache somewhere writable.

### DIFF
--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: Update manifest snapshots
         run: |-
           docker run -i --rm --user $(id -u) \
+            -e XDG_CACHE_HOME=/tmp/cache \
             -v $(pwd):/apps \
             helmunittest/helm-unittest -u \
             chart

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Update manifest snapshots
         run: |-
           docker run -i --rm --user $(id -u) \
-            -e XDG_CACHE_HOME=/tmp/cache \
+            --tmpfs=/.cache \
             -v $(pwd):/apps \
             helmunittest/helm-unittest -u \
             chart


### PR DESCRIPTION
This is the cause of the CI failures. The actions runner runs as user 1001, helm-unittest expects 1000